### PR TITLE
fix: relax engines.node from >=22 to >=18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@integrityxd/wp-rest-api-client",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@integrityxd/wp-rest-api-client",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0"
@@ -30,7 +30,7 @@
         "typescript-eslint": "^8.1.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@integrityxd/wp-rest-api-client",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A low-level npm package for WordPress REST API requests",
   "main": "dist/index.js",
   "types": "index.d.ts",
@@ -13,7 +13,7 @@
     "publish": "npm publish"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=18"
   },
   "keywords": [
     "wordpress",


### PR DESCRIPTION
## Summary

- Relax `engines.node` from `>=22` to `>=18` — the package uses no Node 22-specific APIs
- Bump version to `1.2.2` for npm publish

## Problem

The `>=22` engine constraint causes `yarn install --immutable` failures in downstream consumers running Node 20 (e.g., bpf-rebuild CI). Since the package only uses axios and Buffer, there's no reason to require Node 22.

## Urgency

Blocking bpf-rebuild PR #518 (critical vulnerability remediation). Needs merge + npm publish so bpf-rebuild CI can pass.