### PR TITLE
Allow rettime and @open-draft ESM packages through jest transform

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,7 @@ module.exports = {
     '^.+\\.(ts|tsx|js|jsx|mjs)$': 'ts-jest',
   },
   transformIgnorePatterns: [
-    'node_modules/(?!(msw|@mswjs|until-async)/)'
+    'node_modules/(?!(msw|@mswjs|until-async|rettime|@open-draft)/)'
   ],
   setupFilesAfterEnv: ['<rootDir>/src/test/setupTests.ts'],
 };


### PR DESCRIPTION
## Summary
- Adds `rettime` and `@open-draft` to jest's `transformIgnorePatterns` allowlist
- Newer `msw` (bumped in Dependabot minor-patch group #108) depends on these ESM-only packages; jest fails at import with `Cannot use import statement outside a module`
- Unblocks #108 — once this merges, a `@dependabot rebase` there should go green

## Testing
- Reproduced the #108 failure locally with its lockfile, applied this change: 4/4 tests pass
- Harmless against current dev lockfile (pattern entries just unused until msw bumps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)